### PR TITLE
[Fix] - Service cards when change language to portugues

### DIFF
--- a/src/components/SessionWhatIDo.vue
+++ b/src/components/SessionWhatIDo.vue
@@ -35,8 +35,16 @@ export default {
   name: "SessionAboutMe",
   data() {
     return {
-      selectedCategory: "Python",
-      allCards: [
+      selectedCategory: "Python"
+    }
+  },
+  components: {
+    ServiceCard,
+    ButtonSecondary,
+  },
+  computed: {
+    allCards () {
+      return [
         { 
           title: this.$t("sessionWhatIDo.services.python.title"), 
           categories: ["Python", "Backend"],
@@ -145,12 +153,8 @@ export default {
           icon: require("../assets/technologies-icon/ci-cd-icon.png"),
           text: this.$t("sessionWhatIDo.services.cicd.text")
         },
-      ],
+      ]
     }
-  },
-  components: {
-    ServiceCard,
-    ButtonSecondary,
   },
   methods: {
     selectCategory(category, event) {


### PR DESCRIPTION
This PR has:
- Fixing - When change the language to portuguese, the services cards doesn't change because are a data. Now, they will be a computed.

Screenshots:
![image](https://github.com/user-attachments/assets/17840702-da60-4747-b113-987a3f53882f)
